### PR TITLE
Update N+ license handling to reflect reporting section presence

### DIFF
--- a/client/nginx.go
+++ b/client/nginx.go
@@ -227,7 +227,7 @@ type LicenseReporting struct {
 type NginxLicense struct {
 	ActiveTill uint64 `json:"active_till"`
 	Eval       bool
-	Reporting  LicenseReporting
+	Reporting  *LicenseReporting
 }
 
 // Caches is a map of cache stats by cache zone.


### PR DESCRIPTION
### Proposed changes

Previously there was an assumption that `/api/9/license` will always include the `reporting` subtree ([docs](https://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_license_object)), and if it was absent, related values were [populated with zeroes](https://betterstack.com/community/guides/scaling-go/json-in-go/#2-missing-fields-fallback-to-zero-values) making the whole struct hard to rely on.

With the proposed change, `NginxLicense.Reporting` will be a pointer to the original subtree if it present in the API response, or nil otherwise.

Related to https://github.com/nginx/nginx-prometheus-exporter/pull/1102.

May potentially break other consumers of this package (e.g. https://github.com/nginx/kubernetes-ingress, https://github.com/nginx/nginx-prometheus-exporter) - future dep updates will require appropriate changes.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
