### PR TITLE
Switch to DialContext() to address lint issue

### DIFF
--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -850,7 +850,8 @@ func TestStreamStats(t *testing.T) {
 	}
 
 	// make connection so we have stream server zone stats - ignore response
-	_, err = net.Dial("tcp", helpers.GetStreamAddress())
+	d := &net.Dialer{}
+	_, err = d.DialContext(context.Background(), "tcp", helpers.GetStreamAddress())
 	if err != nil {
 		t.Errorf("Error making tcp connection: %v", err)
 	}


### PR DESCRIPTION
### Proposed changes

Address lint issue
```
[Go Lint: tests/client_test.go#L853](https://github.com/nginx/nginx-plus-go-client/pull/524/files#annotation_37540465072)
net.Dial must not be called. use (*net.Dialer).DialContext (noctx)
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
